### PR TITLE
Improve environment marking

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -85,12 +85,18 @@ runs:
       shell: bash
       name: Create GH Deployment
       run: |
-        DEPLOYMENT_ID=$(echo '{
-          "ref": "${{ inputs.BRANCH_NAME }}",
-          "environment": "${{ env.ENVIRONMENT }}",
-          "auto_merge": false,
-          "required_contexts": []
-        }' | gh api --method POST "/repos/$OWNER/$REPO/deployments" \
+        if [ "${{ inputs.USE_PULL_REQUESTS }}" == "1" ]; then
+          TRANSIENT="true"
+        else
+          TRANSIENT="false"
+        fi
+        DEPLOYMENT_ID=$(echo "{
+          \"ref\": \"${{ inputs.BRANCH_NAME }}\",
+          \"environment\": \"${{ env.ENVIRONMENT }}\",
+          \"auto_merge\": false,
+          \"required_contexts\": [],
+          \"transient_environment\": $TRANSIENT
+        }" | gh api --method POST "/repos/$OWNER/$REPO/deployments" \
           -H "Accept: application/vnd.github+json" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           --input - --jq '.id')

--- a/action.yml
+++ b/action.yml
@@ -90,12 +90,18 @@ runs:
         else
           TRANSIENT="false"
         fi
+        if [ "${{ inputs.BRANCH_NAME }}" == "main" ] || [ "${{ inputs.BRANCH_NAME }}" == "master" ]; then
+          PRODUCTION="true"
+        else
+          PRODUCTION="false"
+        fi
         DEPLOYMENT_ID=$(echo "{
           \"ref\": \"${{ inputs.BRANCH_NAME }}\",
           \"environment\": \"${{ env.ENVIRONMENT }}\",
           \"auto_merge\": false,
           \"required_contexts\": [],
-          \"transient_environment\": $TRANSIENT
+          \"transient_environment\": $TRANSIENT,
+          \"production_environment\": $PRODUCTION
         }" | gh api --method POST "/repos/$OWNER/$REPO/deployments" \
           -H "Accept: application/vnd.github+json" \
           -H "X-GitHub-Api-Version: 2022-11-28" \


### PR DESCRIPTION
This is an attempt at improving how environments are handled on GitHub based on [the available parameters you can provide when creating a deployment using the GitHub API](https://docs.github.com/en/rest/deployments/deployments?apiVersion=2022-11-28#create-a-deployment):

1. Mark PR environments as transient
2. Mark main/master environments as production

Check out the commit comments for additional info.

NB: I have not tested this in practice!